### PR TITLE
Add ability to mock listing remote pinning services via `ipfsClient.pin.remote.service.ls()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,10 @@ The full list of methods available is:
   * `thenReturn(values: Array<{ type, cid }>)` - Return a given list of pins.
   * `thenTimeout()` - Wait forever, returning no response
   * `thenCloseConnection()` - Kills the TCP connection, causing a network error
+* `forPinRemoteLs()` - Mock listing registered remote pinning services
+  * `thenReturn(values: Array<{ service: string, endpoint: URL, stat?: Stat }>)` - Return a given list of remote services.
+  * `thenTimeout()` - Wait forever, returning no response
+  * `thenCloseConnection()` - Kills the TCP connection, causing a network error
 
 ### Examining IPFS requests
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,7 @@ export type { NamePublishRuleBuilder } from './ipns/name-publish-rule-builder';
 export type { NameResolveRuleBuilder } from './ipns/name-resolve-rule-builder';
 export type { PinAddRuleBuilder } from './pinning/pin-add-rule-builder';
 export type { PinLsRuleBuilder } from './pinning/pin-ls-rule-builder';
+export type { PinRemoteLsRuleBuilder } from './pinning/pin-remote-ls-rule-builder';
 export type { PinRmRuleBuilder } from './pinning/pin-rm-rule-builder';
 
 export type { MockedIPFSEndpoint } from './mocked-endpoint';

--- a/src/mockipfs-node.ts
+++ b/src/mockipfs-node.ts
@@ -18,6 +18,7 @@ import { PinningMock } from "./pinning/pinning-mock";
 import { PinAddRuleBuilder } from "./pinning/pin-add-rule-builder";
 import { PinRmRuleBuilder } from "./pinning/pin-rm-rule-builder";
 import { PinLsRuleBuilder } from "./pinning/pin-ls-rule-builder";
+import { PinRemoteLsRuleBuilder } from "./pinning/pin-remote-ls-rule-builder";
 
 export interface MockIPFSOptions {
     /**
@@ -227,6 +228,15 @@ export class MockIPFSNode {
     forPinLs() {
         return new PinLsRuleBuilder(
             this.pinningMock.addPinLsRule
+        );
+    }
+
+    /**
+     * Mock the behaviour of IPFS remote pinning service listing.
+     */
+    forPinRemoteLs() {
+        return new PinRemoteLsRuleBuilder(
+            this.pinningMock.addPinRemoteLsRule
         );
     }
 

--- a/src/pinning/pin-remote-ls-rule-builder.ts
+++ b/src/pinning/pin-remote-ls-rule-builder.ts
@@ -1,0 +1,139 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Tim Perry <tim@httptoolkit.tech>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Mockttp from "mockttp";
+import {
+    RemotePinService,
+    RemotePinServiceWithStat,
+    Stat
+} from "ipfs-core-types/src/pin/remote/service";
+import {
+    buildIpfsFixedValueResponse,
+} from "../utils/http";
+
+/**
+ * A builder to allow defining rules that will mock IPFS pin remote services ls requests.
+ */
+export class PinRemoteLsRuleBuilder {
+
+    /**
+     * This builder should not be constructed directly. Call `mockNode.forPinRemoteLs()` instead.
+     */
+    constructor(
+        private addRuleCallback: (data: Mockttp.RequestRuleData) => Promise<void>
+    ) {}
+
+    /**
+     * Return a successful result, returning the given fixed list of remote pinning services. The parameter
+     * should be an array of `{ service, endpoint, stat? }` objects, where service is the name of the service,
+     * endpoint is the URL of the remote service, and stat is the status and optional pin count object.
+     *
+     * When a request includes the stat=true querystring parameter return the stat object, otherwise exclude it.
+     * Note: if the mock data did not include a stat object, the service is set to have an invalid status.
+     *
+     * This method completes the rule definition, and returns a promise that resolves once the rule is active.
+     */
+    thenReturn(values: Array<RemotePinServiceWithStat | RemotePinService>) {
+        return this.addRuleCallback({
+            matchers: [],
+            handler: new Mockttp.requestHandlerDefinitions.CallbackHandlerDefinition((req) => {
+                const searchParams = new URL(req.url).searchParams;
+                const sendStat = searchParams.get('stat');
+
+                const RemoteServices = values
+                    .map(val => {
+                        const retVal: ServiceResponse = {
+                            Service: val.service,
+                            ApiEndpoint: val.endpoint.toString()
+                        }
+                        if (sendStat === 'true') {
+                            retVal.Stat = getStat(val);
+                        }
+                        return retVal;
+                    });
+
+                return buildIpfsFixedValueResponse(200, { RemoteServices });
+            })
+        });
+    }
+
+    /**
+     * Timeout, accepting the request but never returning a response.
+     *
+     * This method completes the rule definition, and returns a promise that resolves once the rule is active.
+     */
+    thenTimeout() {
+        return this.addRuleCallback({
+            matchers: [],
+            handler: new Mockttp.requestHandlerDefinitions.TimeoutHandlerDefinition()
+        });
+    }
+
+    /**
+     * Close the connection immediately after receiving the matching request, without sending any response.
+     *
+     * This method completes the rule definition, and returns a promise that resolves once the rule is active.
+     */
+    thenCloseConnection() {
+        return this.addRuleCallback({
+            matchers: [],
+            handler: new Mockttp.requestHandlerDefinitions.CloseConnectionHandlerDefinition()
+        });
+    }
+
+}
+
+/**
+ * interfaces that matches a real-life http response
+ */
+interface ServiceResponse {
+    Service: string;
+    ApiEndpoint: string;
+    Stat?: ServiceStat;
+}
+
+interface ServiceStat {
+    Status: 'valid' | 'invalid';
+    PinCount?: {
+        Queued: number;
+        Pinning: number;
+        Pinned: number;
+        Failed: number;
+    };
+}
+
+/**
+ * extract the stat from a value given to the mock
+ */
+function getStat(service: RemotePinServiceWithStat | RemotePinService): ServiceStat {
+    // if the mock was not given a stat value use a default of 'invalid' service
+    if (!serviceHasStat(service)) {
+        return {
+            Status: 'invalid'
+        };
+    }
+
+    const _stat = service.stat;
+    const stat: ServiceStat = {
+        Status: _stat.status
+    };
+    // pinCount may not exist for 'invalid'
+    if (_stat.pinCount) {
+        stat.PinCount = {
+            Queued: _stat.pinCount.queued,
+            Pinning: _stat.pinCount.pinning,
+            Pinned: _stat.pinCount.pinned,
+            Failed: _stat.pinCount.failed
+        };
+    }
+
+    return stat;
+}
+
+function serviceHasStat(
+    service: RemotePinServiceWithStat | RemotePinService
+): service is RemotePinServiceWithStat {
+    return (service as RemotePinServiceWithStat).stat !== undefined;
+}

--- a/src/pinning/pinning-mock.ts
+++ b/src/pinning/pinning-mock.ts
@@ -48,6 +48,15 @@ export class PinningMock {
                 ],
                 completionChecker: new Mockttp.completionCheckers.Always(),
                 handler: new IpfsStreamHandlerDefinition(200)
+            }),
+            this.mockttpServer.addRequestRules({
+                priority: Mockttp.RulePriority.FALLBACK,
+                matchers: [
+                    new Mockttp.matchers.MethodMatcher(Mockttp.Method.POST),
+                    new Mockttp.matchers.SimplePathMatcher('/api/v0/pin/remote/service/ls')
+                ],
+                completionChecker: new Mockttp.completionCheckers.Always(),
+                handler: new Mockttp.requestHandlers.CallbackHandler(this.defaultRemoteLsHandler)
             })
         ]);
     }
@@ -58,6 +67,10 @@ export class PinningMock {
         const value = parsedURL.searchParams.get('arg')!;
 
         return buildIpfsFixedValueResponse(200, { Pins: [value] });
+    };
+
+    defaultRemoteLsHandler: MockttpRequestCallback = async (request: Mockttp.CompletedRequest) => {
+        return buildIpfsFixedValueResponse(200, { RemoteServices: [] });
     };
 
     addPinAddRule = async (ruleData: Mockttp.RequestRuleData) => {
@@ -89,6 +102,17 @@ export class PinningMock {
                 ...ruleData.matchers,
                 new Mockttp.matchers.MethodMatcher(Mockttp.Method.POST),
                 new Mockttp.matchers.SimplePathMatcher('/api/v0/pin/ls')
+            ]
+        });
+    };
+
+    addPinRemoteLsRule = async (ruleData: Mockttp.RequestRuleData) => {
+        await this.mockttpServer.addRequestRules({
+            ...ruleData,
+            matchers: [
+                ...ruleData.matchers,
+                new Mockttp.matchers.MethodMatcher(Mockttp.Method.POST),
+                new Mockttp.matchers.SimplePathMatcher('/api/v0/pin/remote/service/ls')
             ]
         });
     };

--- a/test/integration/pin.spec.ts
+++ b/test/integration/pin.spec.ts
@@ -326,16 +326,6 @@ describe("IPFS pin mocking", () => {
             ])).to.equal('timeout');
         });
 
-        it("can close remote service request connection", async () => {
-            await mockNode.forPinRemoteLs().thenCloseConnection();
-
-            const ipfsClient = IpfsClient.create(mockNode.ipfsOptions);
-
-            const result = await ipfsClient.pin.remote.service.ls().catch(e => e);
-
-            expect(result).to.be.instanceOf(TypeError);
-            expect(result.cause).to.match(/other side closed/i);
-        });
     });
 
 });

--- a/test/test-setup.ts
+++ b/test/test-setup.ts
@@ -11,6 +11,10 @@ import { expect } from "chai";
 
 import type * as IPFS from "ipfs";
 import * as IpfsClient from "ipfs-http-client";
+import {
+    RemotePinService,
+    RemotePinServiceWithStat
+} from "ipfs-core-types/src/pin/remote/service";
 
 import itAll = require('it-all');
 import {
@@ -33,6 +37,13 @@ export {
 
 export const EXAMPLE_CID = 'QmY7Yh4UquoXHLPFo2XbhXkhBvFoPwmQUSa92pxnxjQuPU';
 export const ALTERNATE_CID = 'QmY7Yh4UquoXHLPFo2XbhXkhBvFoPwmQUSa92pxnxjQABC';
+export const EXAMPLE_SERVICE = { service: 'foo', endpoint: new URL('http://localhost:9876/') };
+export const EXAMPLE_ALT_SERVICE = { service: 'bar', endpoint: new URL('http://localhost:6789/') };
+
+export const normalizeService = function (service: RemotePinServiceWithStat | RemotePinService) {
+    const _service = { ...service, endpoint: service.endpoint.toString() };
+    return _service;
+};
 
 export const itValue = async <T>(asyncIterable: AsyncIterable<T>|Iterable<T>): Promise<T> => {
     const values = await itAll(asyncIterable);

--- a/test/test-setup.ts
+++ b/test/test-setup.ts
@@ -4,6 +4,7 @@
  */
 
 import { AbortController } from "node-abort-controller";
+// @ts-ignore
 globalThis.AbortController ??= AbortController;
 
 import { expect } from "chai";


### PR DESCRIPTION
Fixes #2 

@pimterry Here's a first attempt at adding the mock for listing remote pinning services.  I tried to keep everything inline with the current code standards, let me know you have any nits or if I missed anything.
Thanks!